### PR TITLE
Fix/jpg exif orientation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6158,6 +6158,12 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
+    "node_modules/exifr": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/exifr/-/exifr-7.1.3.tgz",
+      "integrity": "sha512-g/aje2noHivrRSLbAUtBPWFbxKdKhgj/xr1vATDdUXPOFYJlQ62Ft0oy+72V6XLIpDJfHs6gXLbBLAolqOXYRw==",
+      "license": "MIT"
+    },
     "node_modules/exit": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
@@ -13681,6 +13687,7 @@
       "dependencies": {
         "@pdfme/common": "*",
         "@pdfme/pdf-lib": "*",
+        "exifr": "^7.1.3",
         "pdfjs-dist": "^3.11.174"
       },
       "devDependencies": {
@@ -13755,6 +13762,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
+        "@pdfme/converter": "*",
         "@pdfme/pdf-lib": "*",
         "air-datepicker": "^3.6.0",
         "bwip-js": "^4.7.0",
@@ -13771,7 +13779,8 @@
         "pngjs": "^7.0.0"
       },
       "peerDependencies": {
-        "@pdfme/common": "latest"
+        "@pdfme/common": "latest",
+        "@pdfme/converter": "latest"
       }
     },
     "packages/schemas/node_modules/pngjs": {

--- a/packages/converter/package.json
+++ b/packages/converter/package.json
@@ -46,6 +46,7 @@
   "dependencies": {
     "@pdfme/common": "*",
     "@pdfme/pdf-lib": "*",
+    "exifr": "^7.1.3",
     "pdfjs-dist": "^3.11.174"
   },
   "devDependencies": {

--- a/packages/converter/src/img2pdf.ts
+++ b/packages/converter/src/img2pdf.ts
@@ -1,41 +1,23 @@
 import { PDFDocument } from '@pdfme/pdf-lib';
 import { mm2pt } from '@pdfme/common';
 import type { ImageType } from './types.js';
+import { detectImageType } from './utils.js';
 
-interface Img2PdfOptions {
+interface Environment {
+  normalizeImageOrientation: (buffer: ArrayBuffer) => Promise<ArrayBuffer>;
+}
+
+export interface Img2PdfOptions {
   scale?: number;
   imageType?: ImageType;
   size?: { height: number; width: number }; // in millimeters
   margin?: [number, number, number, number]; // in millimeters [top, right, bottom, left]
 }
 
-function detectImageType(buffer: ArrayBuffer): 'jpeg' | 'png' | 'unknown' {
-  const bytes = new Uint8Array(buffer);
-
-  if (bytes.length >= 2 && bytes[0] === 0xff && bytes[1] === 0xd8) {
-    return 'jpeg';
-  }
-
-  if (
-    bytes.length >= 8 &&
-    bytes[0] === 0x89 &&
-    bytes[1] === 0x50 &&
-    bytes[2] === 0x4e &&
-    bytes[3] === 0x47 &&
-    bytes[4] === 0x0d &&
-    bytes[5] === 0x0a &&
-    bytes[6] === 0x1a &&
-    bytes[7] === 0x0a
-  ) {
-    return 'png';
-  }
-
-  return 'unknown';
-}
-
 export async function img2pdf(
   imgs: ArrayBuffer[],
   options: Img2PdfOptions = {},
+  env: Environment,
 ): Promise<ArrayBuffer> {
   try {
     const { scale = 1, size, margin = [0, 0, 0, 0] } = options;
@@ -44,21 +26,36 @@ export async function img2pdf(
       throw new Error('Input must be a non-empty array of image buffers');
     }
 
+    const { normalizeImageOrientation } = env;
+
     const doc = await PDFDocument.create();
     for (const img of imgs) {
       try {
         let image;
         const type = detectImageType(img);
+        let processedImg = img;
 
         if (type === 'jpeg') {
-          image = await doc.embedJpg(img);
+          try {
+            /**
+             * pdf-lib's embedJpg does not interpret EXIF Orientation, so the direction is reflected in advance.
+             * @see https://github.com/Hopding/pdf-lib/issues/1284
+             */
+            processedImg = await normalizeImageOrientation(img);
+          } catch (error) {
+            console.warn('[@pdfme/converter] Failed to normalize image orientation:', error);
+          }
+        }
+
+        if (type === 'jpeg') {
+          image = await doc.embedJpg(processedImg);
         } else if (type === 'png') {
-          image = await doc.embedPng(img);
+          image = await doc.embedPng(processedImg);
         } else {
           try {
-            image = await doc.embedJpg(img);
+            image = await doc.embedJpg(processedImg);
           } catch {
-            image = await doc.embedPng(img);
+            image = await doc.embedPng(processedImg);
           }
         }
 

--- a/packages/converter/src/index.browser.ts
+++ b/packages/converter/src/index.browser.ts
@@ -1,10 +1,11 @@
 import * as pdfjsLib from 'pdfjs-dist';
-// @ts-expect-error - PDFJSWorker import is not properly typed but required for functionality
-import PDFJSWorker from 'pdfjs-dist/build/pdf.worker.entry.js';
 import { pdf2img as _pdf2img, Pdf2ImgOptions } from './pdf2img.js';
 import { pdf2size as _pdf2size, Pdf2SizeOptions } from './pdf2size.js';
 
-pdfjsLib.GlobalWorkerOptions.workerSrc = PDFJSWorker as unknown as string;
+pdfjsLib.GlobalWorkerOptions.workerSrc = new URL(
+  'pdfjs-dist/build/pdf.worker.entry.js',
+  import.meta.url,
+).toString();
 
 function dataURLToArrayBuffer(dataURL: string): ArrayBuffer {
   // Split out the actual base64 string from the data URL scheme

--- a/packages/converter/src/index.browser.ts
+++ b/packages/converter/src/index.browser.ts
@@ -1,14 +1,13 @@
 import * as pdfjsLib from 'pdfjs-dist';
+// @ts-expect-error - PDFJSWorker import is not properly typed but required for functionality
+import PDFJSWorker from 'pdfjs-dist/build/pdf.worker.entry.js';
 import { pdf2img as _pdf2img, Pdf2ImgOptions } from './pdf2img.js';
-import { pdf2size as _pdf2size, Pdf2SizeOptions } from './pdf2size.js';
-import { img2pdf as _img2pdf, Img2PdfOptions } from './img2pdf.js';
 import { normalizeImageOrientation as _normalizeImageOrientation } from './normalizeImageOrientation.js';
+import { pdf2size as _pdf2size, Pdf2SizeOptions } from './pdf2size.js';
 import { detectImageType } from './utils.js';
+import { img2pdf as _img2pdf, Img2PdfOptions } from './img2pdf.js';
 
-pdfjsLib.GlobalWorkerOptions.workerSrc = new URL(
-  'pdfjs-dist/build/pdf.worker.min.js',
-  import.meta.url,
-).toString();
+pdfjsLib.GlobalWorkerOptions.workerSrc = PDFJSWorker as unknown as string;
 
 export const arrayBufferToDataURL = (buffer: ArrayBuffer): Promise<string> => {
   return new Promise((resolve, reject) => {

--- a/packages/converter/src/index.browser.ts
+++ b/packages/converter/src/index.browser.ts
@@ -1,13 +1,14 @@
 import * as pdfjsLib from 'pdfjs-dist';
-// @ts-expect-error - PDFJSWorker import is not properly typed but required for functionality
-import PDFJSWorker from 'pdfjs-dist/build/pdf.worker.entry.js';
 import { pdf2img as _pdf2img, Pdf2ImgOptions } from './pdf2img.js';
 import { pdf2size as _pdf2size, Pdf2SizeOptions } from './pdf2size.js';
 import { img2pdf as _img2pdf, Img2PdfOptions } from './img2pdf.js';
 import { normalizeImageOrientation as _normalizeImageOrientation } from './normalizeImageOrientation.js';
 import { detectImageType } from './utils.js';
 
-pdfjsLib.GlobalWorkerOptions.workerSrc = PDFJSWorker as unknown as string;
+pdfjsLib.GlobalWorkerOptions.workerSrc = new URL(
+  'pdfjs-dist/build/pdf.worker.min.js',
+  import.meta.url,
+).toString();
 
 export const arrayBufferToDataURL = (buffer: ArrayBuffer): Promise<string> => {
   return new Promise((resolve, reject) => {

--- a/packages/converter/src/index.browser.ts
+++ b/packages/converter/src/index.browser.ts
@@ -3,10 +3,37 @@ import * as pdfjsLib from 'pdfjs-dist';
 import PDFJSWorker from 'pdfjs-dist/build/pdf.worker.entry.js';
 import { pdf2img as _pdf2img, Pdf2ImgOptions } from './pdf2img.js';
 import { pdf2size as _pdf2size, Pdf2SizeOptions } from './pdf2size.js';
+import { img2pdf as _img2pdf, Img2PdfOptions } from './img2pdf.js';
+import { normalizeImageOrientation as _normalizeImageOrientation } from './normalizeImageOrientation.js';
+import { detectImageType } from './utils.js';
 
 pdfjsLib.GlobalWorkerOptions.workerSrc = PDFJSWorker as unknown as string;
 
-function dataURLToArrayBuffer(dataURL: string): ArrayBuffer {
+export const arrayBufferToDataURL = (buffer: ArrayBuffer): Promise<string> => {
+  return new Promise((resolve, reject) => {
+    const type = detectImageType(buffer);
+    const mimeType = type === 'jpeg' ? 'image/jpeg' : 'image/png';
+
+    const blob = new Blob([buffer], { type: mimeType });
+    const reader = new FileReader();
+
+    reader.onloadend = () => {
+      if (typeof reader.result === 'string') {
+        resolve(reader.result);
+      } else {
+        reject(new Error('Failed to File loadend'));
+      }
+    };
+
+    reader.onerror = () => {
+      reject(reader.error ?? new Error('FileReader error'));
+    };
+
+    reader.readAsDataURL(blob);
+  });
+};
+
+export const dataURLToArrayBuffer = (dataURL: string): ArrayBuffer => {
   // Split out the actual base64 string from the data URL scheme
   const base64String = dataURL.split(',')[1];
 
@@ -22,7 +49,7 @@ function dataURLToArrayBuffer(dataURL: string): ArrayBuffer {
   }
 
   return arrayBuffer;
-}
+};
 
 export const pdf2img = async (
   pdf: ArrayBuffer | Uint8Array,
@@ -48,4 +75,67 @@ export const pdf2size = async (pdf: ArrayBuffer | Uint8Array, options: Pdf2SizeO
     getDocument: (pdf) => pdfjsLib.getDocument({ data: pdf, isEvalSupported: false }).promise,
   });
 
-export { img2pdf } from './img2pdf.js';
+export const img2pdf = async (
+  imgs: ArrayBuffer[],
+  options: Img2PdfOptions = {},
+): Promise<ArrayBuffer> =>
+  _img2pdf(imgs, options, {
+    normalizeImageOrientation: normalizeImageOrientation,
+  });
+
+export const normalizeImageOrientation = async (buffer: ArrayBuffer): Promise<ArrayBuffer> =>
+  _normalizeImageOrientation(buffer, {
+    applyRotation: (buffer, rotation) =>
+      new Promise((resolve, reject) => {
+        const blob = new Blob([buffer], { type: 'image/jpeg' });
+        const url = URL.createObjectURL(blob);
+        const img = new Image();
+
+        img.onload = () => {
+          try {
+            const canvas = document.createElement('canvas');
+            const ctx = canvas.getContext('2d');
+            if (!ctx) {
+              throw new Error('[@pdfme/converter] Failed to get canvas context');
+            }
+
+            // Rotation is already applied.
+            if (!rotation.canvas) {
+              canvas.width = img.width;
+              canvas.height = img.height;
+              ctx.drawImage(img, 0, 0);
+            } else {
+              canvas.width = rotation.dimensionSwapped ? img.height : img.width;
+              canvas.height = rotation.dimensionSwapped ? img.width : img.height;
+
+              // Set the origin at the center of the canvas.
+              ctx.translate(canvas.width / 2, canvas.height / 2);
+
+              ctx.rotate(rotation.rad);
+              ctx.scale(rotation.scaleX, rotation.scaleY);
+
+              ctx.drawImage(img, -img.width / 2, -img.height / 2);
+            }
+
+            canvas.toBlob((blob) => {
+              if (!blob) {
+                reject(new Error('[@pdfme/converter] Failed to create blob'));
+                return;
+              }
+              blob.arrayBuffer().then(resolve).catch(reject);
+            }, 'image/jpeg');
+          } catch {
+            reject(new Error('[@pdfme/converter] Failed to draw canvas image'));
+          } finally {
+            URL.revokeObjectURL(url);
+          }
+        };
+
+        img.onerror = () => {
+          URL.revokeObjectURL(url);
+          reject(new Error('Failed to load image'));
+        };
+        img.src = url;
+      }),
+    dataURLToArrayBuffer: dataURLToArrayBuffer,
+  });

--- a/packages/converter/src/index.node.ts
+++ b/packages/converter/src/index.node.ts
@@ -1,11 +1,30 @@
 import * as pdfjsLib from 'pdfjs-dist/legacy/build/pdf';
 // @ts-expect-error - PDFJSWorker import is not properly typed but required for functionality
 import PDFJSWorker from 'pdfjs-dist/legacy/build/pdf.worker.js';
-import { createCanvas } from 'canvas';
+import { createCanvas, loadImage } from 'canvas';
 import { pdf2img as _pdf2img, Pdf2ImgOptions } from './pdf2img.js';
 import { pdf2size as _pdf2size, Pdf2SizeOptions } from './pdf2size.js';
+import { img2pdf as _img2pdf, Img2PdfOptions } from './img2pdf.js';
+import { normalizeImageOrientation as _normalizeImageOrientation } from './normalizeImageOrientation.js';
+import { detectImageType } from './utils.js';
 
 pdfjsLib.GlobalWorkerOptions.workerSrc = PDFJSWorker as unknown as string;
+
+export const arrayBufferToDataURL = (buffer: ArrayBuffer): Promise<string> => {
+  const type = detectImageType(buffer);
+  const mimeType = type === 'jpeg' ? 'image/jpeg' : 'image/png';
+  const base64String = Buffer.from(buffer).toString('base64');
+  const dataUrl = `data:${mimeType};base64,${base64String}`;
+
+  return Promise.resolve(dataUrl);
+};
+
+export const dataURLToArrayBuffer = (dataURL: string): ArrayBuffer => {
+  const base64String = dataURL.split(',')[1];
+  const buffer = Buffer.from(base64String, 'base64');
+
+  return buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength);
+};
 
 export const pdf2img = async (
   pdf: ArrayBuffer | Uint8Array,
@@ -30,4 +49,40 @@ export const pdf2size = async (pdf: ArrayBuffer | Uint8Array, options: Pdf2SizeO
     getDocument: (pdf) => pdfjsLib.getDocument({ data: pdf, isEvalSupported: false }).promise,
   });
 
-export { img2pdf } from './img2pdf.js';
+export const img2pdf = async (
+  imgs: ArrayBuffer[],
+  options: Img2PdfOptions = {},
+): Promise<ArrayBuffer> =>
+  _img2pdf(imgs, options, {
+    normalizeImageOrientation: normalizeImageOrientation,
+  });
+
+export const normalizeImageOrientation = async (buffer: ArrayBuffer): Promise<ArrayBuffer> =>
+  _normalizeImageOrientation(buffer, {
+    applyRotation: async (buffer, rotation) => {
+      const nodeBuffer = Buffer.from(buffer);
+      const img = await loadImage(nodeBuffer);
+
+      const canvasWidth = rotation.dimensionSwapped ? img.height : img.width;
+      const canvasHeight = rotation.dimensionSwapped ? img.width : img.height;
+
+      const canvas = createCanvas(canvasWidth, canvasHeight);
+      const ctx = canvas.getContext('2d');
+
+      // Set the origin at the center of the canvas.
+      ctx.translate(canvasWidth / 2, canvasHeight / 2);
+
+      ctx.rotate(rotation.rad);
+      ctx.scale(rotation.scaleX, rotation.scaleY);
+
+      ctx.drawImage(img, -img.width / 2, -img.height / 2);
+
+      const newBuffer = canvas.toBuffer('image/jpeg');
+      const arrayBuffer = new ArrayBuffer(newBuffer.byteLength);
+      const view = new Uint8Array(arrayBuffer);
+      view.set(newBuffer);
+
+      return arrayBuffer;
+    },
+    dataURLToArrayBuffer: dataURLToArrayBuffer,
+  });

--- a/packages/converter/src/normalizeImageOrientation.ts
+++ b/packages/converter/src/normalizeImageOrientation.ts
@@ -1,0 +1,78 @@
+import exifr from 'exifr';
+import { detectImageType } from './utils.js';
+
+enum Orientation {
+  Horizontal = 1,
+  MirrorHorizontal = 2,
+  Rotate180 = 3,
+  MirrorVertical = 4,
+  MirrorHorizontalAndRotate270CW = 5,
+  Rotate90CW = 6,
+  MirrorHorizontalAndRotate90CW = 7,
+  Rotate270CW = 8,
+}
+
+export async function getImageOrientation(buffer: ArrayBuffer): Promise<Orientation | undefined> {
+  try {
+    return await exifr.orientation(buffer);
+  } catch (error) {
+    console.warn('[@pdfme/converter] Failed to read EXIF orientation:', error);
+    return undefined;
+  }
+}
+
+interface Rotation {
+  deg: number;
+  rad: number;
+  scaleX: number;
+  scaleY: number;
+  dimensionSwapped: boolean;
+  css: boolean;
+  canvas: boolean;
+}
+
+export async function getImageRotation(buffer: ArrayBuffer): Promise<Rotation | undefined> {
+  try {
+    return await exifr.rotation(buffer);
+  } catch (error) {
+    console.warn('[@pdfme/converter] Failed to read EXIF rotation:', error);
+    return undefined;
+  }
+}
+
+interface Environment {
+  applyRotation: (buffer: ArrayBuffer, rotation: Rotation) => Promise<ArrayBuffer>;
+  dataURLToArrayBuffer: (dataURL: string) => ArrayBuffer;
+}
+
+export async function normalizeImageOrientation(
+  buffer: ArrayBuffer,
+  env: Environment,
+): Promise<ArrayBuffer> {
+  const { applyRotation } = env;
+
+  try {
+    const type = detectImageType(buffer);
+
+    if (type !== 'jpeg') {
+      return buffer;
+    }
+
+    const orientation = await getImageOrientation(buffer);
+    if (!orientation || orientation === Orientation.Horizontal) {
+      return buffer;
+    }
+
+    const rotation = await getImageRotation(buffer);
+    if (!rotation) {
+      return buffer;
+    }
+
+    const normalizedBuffer = await applyRotation(buffer, rotation);
+
+    return normalizedBuffer;
+  } catch (error) {
+    console.warn('[@pdfme/converter] Failed to normalize image orientation:', error);
+    return buffer;
+  }
+}

--- a/packages/converter/src/utils.ts
+++ b/packages/converter/src/utils.ts
@@ -1,0 +1,23 @@
+export function detectImageType(buffer: ArrayBuffer): 'jpeg' | 'png' | 'unknown' {
+  const bytes = new Uint8Array(buffer);
+
+  if (bytes.length >= 2 && bytes[0] === 0xff && bytes[1] === 0xd8) {
+    return 'jpeg';
+  }
+
+  if (
+    bytes.length >= 8 &&
+    bytes[0] === 0x89 &&
+    bytes[1] === 0x50 &&
+    bytes[2] === 0x4e &&
+    bytes[3] === 0x47 &&
+    bytes[4] === 0x0d &&
+    bytes[5] === 0x0a &&
+    bytes[6] === 0x1a &&
+    bytes[7] === 0x0a
+  ) {
+    return 'png';
+  }
+
+  return 'unknown';
+}

--- a/packages/converter/tsconfig.cjs.json
+++ b/packages/converter/tsconfig.cjs.json
@@ -6,5 +6,6 @@
     "declaration": true,
     "declarationDir": "dist/types",
     "skipLibCheck": true
-  }
+  },
+  "exclude": ["src/**/*.browser.ts"]
 }

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -55,6 +55,7 @@
     "prettier": "prettier --write 'src/**/*.ts'"
   },
   "dependencies": {
+    "@pdfme/converter": "*",
     "@pdfme/pdf-lib": "*",
     "air-datepicker": "^3.6.0",
     "bwip-js": "^4.7.0",
@@ -71,7 +72,8 @@
     "pngjs": "^7.0.0"
   },
   "peerDependencies": {
-    "@pdfme/common": "latest"
+    "@pdfme/common": "latest",
+    "@pdfme/converter": "latest"
   },
   "jest": {
     "resolver": "ts-jest-resolver",

--- a/packages/schemas/src/graphics/image.ts
+++ b/packages/schemas/src/graphics/image.ts
@@ -27,16 +27,38 @@ const imageSchema: Plugin<ImageSchema> = {
     const { value, schema, pdfDoc, page, _cache } = arg;
     if (!value) return;
 
-    const inputImageCacheKey = getCacheKey(schema, value);
+    let dataUrl = value;
+    const isPng = dataUrl.startsWith('data:image/png;');
+
+    if (!isPng) {
+      try {
+        /**
+         * pdf-lib's embedJpg does not interpret EXIF Orientation, so the direction is reflected in advance.
+         * @see https://github.com/Hopding/pdf-lib/issues/1284
+         */
+        /**
+         * TODO: 実行時にWarningが発生して問題になっている
+         * installHook.js:1 SyntaxError: The requested module '/node_modules/.vite/deps/pdfjs-dist_build_pdf__worker__entry__js.js?v=0b0a5bfb' does not provide an export named 'default' (at index.browser.ts:3:8)
+         */
+        const { normalizeImageOrientation, arrayBufferToDataURL, dataURLToArrayBuffer } =
+          await import('@pdfme/converter');
+        const buffer = dataURLToArrayBuffer(dataUrl);
+        const normalizedBuffer = await normalizeImageOrientation(buffer);
+        dataUrl = await arrayBufferToDataURL(normalizedBuffer);
+      } catch (error) {
+        console.warn('[@pdfme/schemas] Failed to normalize image orientation:', error);
+      }
+    }
+
+    const inputImageCacheKey = getCacheKey(schema, dataUrl);
     let image = _cache.get(inputImageCacheKey) as PDFImage;
     if (!image) {
-      const isPng = value.startsWith('data:image/png;');
-      image = await (isPng ? pdfDoc.embedPng(value) : pdfDoc.embedJpg(value));
+      image = await (isPng ? pdfDoc.embedPng(dataUrl) : pdfDoc.embedJpg(dataUrl));
       _cache.set(inputImageCacheKey, image);
     }
 
     const _schema = { ...schema, position: { ...schema.position } };
-    const dimension = getImageDimension(value);
+    const dimension = getImageDimension(dataUrl);
     const imageWidth = px2mm(dimension.width);
     const imageHeight = px2mm(dimension.height);
     const boxWidth = _schema.width;


### PR DESCRIPTION
**Workerの読み込み不具合の次にpdfme/pdfmeにPRを立てる予定**

--------

## Overview
We have addressed the issue described in https://github.com/pdfme/pdfme/issues/1183.
This problem arises because pdf-lib does not interpret the orientation specified in a JPEG's EXIF data when creating a PDF (https://github.com/Hopding/pdf-lib/issues/1284).
In light of the situation in the aforementioned issue, we have implemented a solution within pdfme.

### Scope of Impact
- @pdfme/schemas
- @pdfme/converter
- playground

### Solution
We have modified the process to ensure that images with EXIF Orientation set are displayed correctly in PDFs, matching the preview, in both browser and Node.js environments. This was achieved by using [exifr (※1)](https://github.com/MikeKovarik/exifr) for image conversion.

## Screenshots

### Template
[template.json](https://github.com/user-attachments/files/24048097/template.json)

<img width="300"  alt="template_screenshot" src="https://github.com/user-attachments/assets/fa57373b-b923-4535-9212-f9513d46c68e" />


### Before generated PDF
[before.pdf](https://github.com/user-attachments/files/24048090/before.pdf)

<img width="300" alt="before" src="https://github.com/user-attachments/assets/2fe1e8d2-2b82-4a75-8b6f-94ebb2807125" />

### After generated PDF
[after.pdf](https://github.com/user-attachments/files/24048114/after.pdf)

<img width="300" alt="after" src="https://github.com/user-attachments/assets/694af540-fead-4b78-b754-8af61c6f6471" />



## Testing
- `@pdfme/schemas`
  - node
    - [ ] EIXF Orientation of JPEG images is reflected when creating PDFs with the generator.
    - [ ] When EIXF Orientation of JPEG images is not set during PDF creation with the generator, it is reflected as is.
  - browser
    - [ ] EIXF Orientation of JPEG images is reflected when creating PDFs with the generator.
    - [ ] When EIXF Orientation of JPEG images is not set during PDF creation with the generator, it is reflected as is.
- `@pdfme/converter`
  - node
    - [ ] EIXF Orientation of JPEG images is reflected when creating PDFs with img2pdf.
    - [ ] When EIXF Orientation of JPEG images is not set during PDF creation with img2pdf, the image is displayed as is.
  - browser
    - [ ] EIXF Orientation of JPEG images is reflected when creating PDFs with img2pdf.
    - [ ] When EIXF Orientation of JPEG images is not set during PDF creation with img2pdf, the image is displayed as is.
- playground
    - [ ] It is possible to create a PDF from a template with EXIF Orientation settings.
    
  
## Appendix(※)
#### ※1: Background for adopting exifr
- Parsing image information is a highly specialized task, so we wanted to leverage a major OSS rather than implementing everything from scratch.
- [npm trends advantages](https://npmtrends.com/exif-js-vs-exif-reader-vs-exifr)
- It provides all the necessary properties for coordinate calculations.
